### PR TITLE
feat: preauthorization integration for seamless pot entries

### DIFF
--- a/lucky_pot.py
+++ b/lucky_pot.py
@@ -5,7 +5,7 @@ from loguru import logger
 from luckypot import db
 from luckypot.config import settings
 import stackcoin
-from luckypot.game import on_request_accepted, on_request_denied
+from luckypot.game import on_request_accepted, on_request_denied, backfill_preauths_for_auto_enter_users
 from luckypot import stk
 from luckypot.stk import get_client as get_stk_client
 from luckypot.discord.bot import (
@@ -86,6 +86,14 @@ async def on_started(_event: hikari.StartedEvent) -> None:
     gateway_task.add_done_callback(_task_done_callback)
     background_tasks.append(gateway_task)
     logger.info("StackCoin gateway started")
+
+    # TEMPORARY: backfill preauths for existing auto-enter users.
+    # Remove once all users have been sent preauth requests.
+    backfill_task = asyncio.create_task(
+        backfill_preauths_for_auto_enter_users(),
+        name="preauth-backfill",
+    )
+    backfill_task.add_done_callback(_task_done_callback)
 
     draw_task = asyncio.create_task(
         run_daily_draw_loop(

--- a/luckypot/db.py
+++ b/luckypot/db.py
@@ -320,6 +320,12 @@ def get_auto_enter_users(conn, guild_id: str) -> list[str]:
     return [row["discord_id"] for row in cursor.fetchall()]
 
 
+def get_all_auto_enter_users(conn) -> list[dict]:
+    """Return all auto-enter users across all guilds."""
+    cursor = conn.execute("SELECT discord_id, guild_id FROM auto_enter_users")
+    return [{"discord_id": row["discord_id"], "guild_id": row["guild_id"]} for row in cursor.fetchall()]
+
+
 def get_auto_enter_status(conn, discord_id: str, guild_id: str) -> bool:
     """Return True if the user is opted in to auto-enter for this guild."""
     cursor = conn.execute(

--- a/luckypot/discord/commands.py
+++ b/luckypot/discord/commands.py
@@ -57,6 +57,17 @@ def register_commands(client: lightbulb.Client, bot: hikari.GatewayBot) -> None:
                     await ctx.respond(
                         components=[container], flags=hikari.MessageFlag.EPHEMERAL
                     )
+                elif status == "confirmed":
+                    container = ui.build_entry_confirmed()
+                    await ctx.respond(
+                        components=[container], flags=hikari.MessageFlag.EPHEMERAL
+                    )
+                elif status == "skipped":
+                    message = result.get("message", "Entry skipped.")
+                    container = ui.build_entry_error(message)
+                    await ctx.respond(
+                        components=[container], flags=hikari.MessageFlag.EPHEMERAL
+                    )
                 elif status == "already_entered":
                     container = ui.build_entry_already_entered()
                     await ctx.respond(
@@ -171,7 +182,30 @@ def register_commands(client: lightbulb.Client, bot: hikari.GatewayBot) -> None:
                     conn.close()
 
                 if self.enabled:
-                    container = ui.build_auto_enter_opted_in()
+                    # Check/request preauth for seamless auto-enter
+                    from luckypot import stk as stk_mod
+                    stk_user = await stk_mod.get_user_by_discord_id(discord_id)
+                    if stk_user:
+                        preauths = await stk_mod.get_preauths(user_id=stk_user["id"])
+                        active = [p for p in preauths if p.get("status") == "active"]
+                        pending = [p for p in preauths if p.get("status") == "pending"]
+
+                        if active:
+                            container = ui.build_auto_enter_opted_in_with_preauth()
+                        elif pending:
+                            container = ui.build_auto_enter_opted_in_pending_preauth()
+                        else:
+                            result = await stk_mod.create_preauth(
+                                user_id=stk_user["id"],
+                                max_amount=10,
+                                window_hours=24,
+                            )
+                            if result:
+                                container = ui.build_auto_enter_opted_in_preauth_requested()
+                            else:
+                                container = ui.build_auto_enter_opted_in()
+                    else:
+                        container = ui.build_auto_enter_opted_in()
                 else:
                     container = ui.build_auto_enter_opted_out()
                 await ctx.respond(

--- a/luckypot/discord/ui.py
+++ b/luckypot/discord/ui.py
@@ -152,6 +152,53 @@ def build_auto_enter_opted_out() -> ContainerComponentBuilder:
     return container
 
 
+def build_entry_confirmed() -> ContainerComponentBuilder:
+    """Entry confirmed via preauth."""
+    container = ContainerComponentBuilder(accent_color=BRAND_COLOR)
+    container.add_text_display("✅ Entry Confirmed!")
+    container.add_separator(divider=True, spacing=hikari.SpacingType.SMALL)
+    container.add_text_display(
+        "Your entry has been confirmed! 5 STK was automatically deducted via your preauthorization."
+    )
+    return container
+
+
+def build_auto_enter_opted_in_with_preauth() -> ContainerComponentBuilder:
+    """Auto-enter enabled with active preauth."""
+    container = ContainerComponentBuilder(accent_color=BRAND_COLOR)
+    container.add_text_display("✅ Auto-Enter Enabled")
+    container.add_separator(divider=True, spacing=hikari.SpacingType.SMALL)
+    container.add_text_display(
+        "You will automatically enter each new pot when one starts.\n\n"
+        "Automatic payments are active — entries will be confirmed instantly!"
+    )
+    return container
+
+
+def build_auto_enter_opted_in_pending_preauth() -> ContainerComponentBuilder:
+    """Auto-enter enabled, preauth pending approval."""
+    container = ContainerComponentBuilder(accent_color=BRAND_COLOR)
+    container.add_text_display("✅ Auto-Enter Enabled")
+    container.add_separator(divider=True, spacing=hikari.SpacingType.SMALL)
+    container.add_text_display(
+        "You will automatically enter each new pot when one starts.\n\n"
+        "Check your DMs from StackCoin to approve automatic payments for seamless entries."
+    )
+    return container
+
+
+def build_auto_enter_opted_in_preauth_requested() -> ContainerComponentBuilder:
+    """Auto-enter enabled, preauth just requested."""
+    container = ContainerComponentBuilder(accent_color=BRAND_COLOR)
+    container.add_text_display("✅ Auto-Enter Enabled")
+    container.add_separator(divider=True, spacing=hikari.SpacingType.SMALL)
+    container.add_text_display(
+        "You will automatically enter each new pot when one starts.\n\n"
+        "Check your DMs from StackCoin to approve automatic payments for seamless entries."
+    )
+    return container
+
+
 def build_auto_enter_already_in_state(enabled: bool) -> ContainerComponentBuilder:
     """Build response when user is already in the requested state."""
     container = ContainerComponentBuilder(accent_color=BRAND_COLOR)

--- a/luckypot/game.py
+++ b/luckypot/game.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from functools import partial
 from typing import Any, Callable, Awaitable
 
+import stackcoin
 from loguru import logger
 from luckypot import db, stk
 from luckypot.config import settings
@@ -134,12 +135,19 @@ async def enter_pot(
                 (pot_id, discord_id),
             ).fetchone()["count"]
             idempotency_key = f"pot_entry:{pot_id}:{discord_id}:{prior_attempts + 1}"
-            req = await stk.create_request(
-                to_user_id=stk_user_id,
-                amount=POT_ENTRY_COST,
-                label=f"LuckyPot entry (pot #{pot_id})",
-                idempotency_key=idempotency_key,
-            )
+            try:
+                req = await stk.create_request(
+                    to_user_id=stk_user_id,
+                    amount=POT_ENTRY_COST,
+                    label=f"LuckyPot entry (pot #{pot_id})",
+                    idempotency_key=idempotency_key,
+                    use_preauth=True,
+                )
+            except stackcoin.StackCoinError:
+                return {
+                    "status": "skipped",
+                    "message": "Auto-payment limit reached or insufficient balance.",
+                }
             if req is None:
                 return {
                     "status": "error",
@@ -164,6 +172,25 @@ async def enter_pot(
                 return {
                     "status": "error",
                     "message": "Failed to record your pot entry. The StackCoin request was cancelled; please try again.",
+                }
+
+            # If preauth resolved the request instantly, confirm the entry now
+            if req.get("status") == "accepted":
+                db.confirm_entry(conn, entry_id)
+                if announce_fn:
+                    pot = db.get_active_pot(conn, guild_id)
+                    total_pot = 0
+                    if pot:
+                        participants = db.get_pot_participants(conn, pot["pot_id"])
+                        total_pot = sum(p["amount"] for p in participants)
+                    await announce_fn(
+                        f"<@{discord_id}> entered the pot! The pot is now at {total_pot} STK. Use `/enter-pot` to enter!"
+                    )
+                return {
+                    "status": "confirmed",
+                    "entry_id": entry_id,
+                    "request_id": request_id,
+                    "message": f"Entry confirmed! {POT_ENTRY_COST} STK was automatically deducted.",
                 }
 
             return {

--- a/luckypot/game.py
+++ b/luckypot/game.py
@@ -470,6 +470,69 @@ async def daily_pot_draw(
                 conn.close()
 
 
+# ── TEMPORARY: preauth migration for existing auto-enter users ──────────
+# Remove this function and its call in lucky_pot.py once all existing
+# auto-enter users have been sent preauth requests.
+
+
+async def backfill_preauths_for_auto_enter_users() -> None:
+    """Request preauths for existing auto-enter users who don't have one yet.
+
+    TEMPORARY — safe to remove after rollout once preauths have been sent.
+    """
+    conn = db.get_connection()
+    try:
+        all_users = db.get_all_auto_enter_users(conn)
+    finally:
+        conn.close()
+
+    if not all_users:
+        logger.info("Preauth backfill: no auto-enter users found")
+        return
+
+    # Deduplicate by discord_id (a user may be auto-entered in multiple guilds,
+    # but preauths are per-user not per-guild)
+    seen: set[str] = set()
+    unique_users: list[str] = []
+    for entry in all_users:
+        if entry["discord_id"] not in seen:
+            seen.add(entry["discord_id"])
+            unique_users.append(entry["discord_id"])
+
+    logger.info(f"Preauth backfill: checking {len(unique_users)} auto-enter user(s)")
+    requested = 0
+
+    for discord_id in unique_users:
+        try:
+            stk_user = await stk.get_user_by_discord_id(discord_id)
+            if stk_user is None:
+                continue
+
+            preauths = await stk.get_preauths(user_id=stk_user["id"])
+            has_active_or_pending = any(
+                p.get("status") in ("active", "pending") for p in preauths
+            )
+            if has_active_or_pending:
+                continue
+
+            result = await stk.create_preauth(
+                user_id=stk_user["id"],
+                max_amount=10,
+                window_hours=24,
+            )
+            if result:
+                requested += 1
+                logger.info(
+                    f"Preauth backfill: requested preauth for discord_id={discord_id} (user {stk_user['id']})"
+                )
+        except Exception:
+            logger.exception(
+                f"Preauth backfill: failed for discord_id={discord_id}"
+            )
+
+    logger.info(f"Preauth backfill: done, requested {requested} new preauth(s)")
+
+
 async def on_request_accepted(
     event_data: RequestAcceptedData, announce: RawAnnounceFn = None
 ):

--- a/luckypot/stk.py
+++ b/luckypot/stk.py
@@ -114,27 +114,62 @@ async def send_stk(
         return None
 
 
+async def create_preauth(
+    user_id: int,
+    max_amount: int,
+    window_hours: int,
+) -> dict | None:
+    """Request a preauthorization from a user."""
+    try:
+        return await get_client().create_preauth(
+            user_id=user_id,
+            max_amount=max_amount,
+            window_hours=window_hours,
+        )
+    except stackcoin.StackCoinError as e:
+        logger.error(f"Failed to create preauth for user {user_id}: {e}")
+        return None
+
+
+async def get_preauths(user_id: int | None = None) -> list[dict]:
+    """List preauths for this bot."""
+    try:
+        return await get_client().get_preauths(user_id=user_id)
+    except stackcoin.StackCoinError as e:
+        logger.error(f"Failed to get preauths: {e}")
+        return []
+
+
 async def create_request(
     to_user_id: int,
     amount: int,
     label: str | None = None,
     idempotency_key: str | None = None,
+    use_preauth: bool = False,
 ) -> dict | None:
-    """Create a payment request. Returns response dict or None on failure."""
+    """Create a payment request. Returns response dict or None on failure.
+
+    Raises StackCoinError for preauth_limit_exceeded so callers can handle it.
+    """
     try:
         result = await get_client().create_request(
             to_user_id=to_user_id,
             amount=amount,
             label=label,
             idempotency_key=idempotency_key,
+            use_preauth=use_preauth,
         )
         return {
             "success": result.success,
             "request_id": result.request_id,
             "amount": result.amount,
             "status": result.status,
+            "transaction_id": result.transaction_id,
         }
     except stackcoin.StackCoinError as e:
+        error_str = str(e).lower()
+        if "preauth_limit_exceeded" in error_str:
+            raise
         logger.error(
             f"Failed to create request for {amount} STK from user {to_user_id}: {e}"
         )

--- a/luckypot/stk.py
+++ b/luckypot/stk.py
@@ -68,16 +68,6 @@ async def get_user_by_discord_id(discord_id: str) -> dict | None:
         return None
 
 
-async def get_bot_user() -> dict | None:
-    """Get the bot's own StackCoin user profile."""
-    try:
-        user = await get_client().get_me()
-        return {"id": user.id, "username": user.username, "balance": user.balance}
-    except stackcoin.StackCoinError as e:
-        logger.error(f"Failed to get bot user: {e}")
-        return None
-
-
 async def get_bot_balance() -> int | None:
     """Get the bot's current STK balance."""
     try:
@@ -140,15 +130,6 @@ async def get_preauths(user_id: int | None = None) -> list[dict]:
         return []
 
 
-async def revoke_preauth(preauth_id: int) -> dict | None:
-    """Revoke a preauthorization."""
-    try:
-        return await get_client().revoke_preauth(preauth_id=preauth_id)
-    except stackcoin.StackCoinError as e:
-        logger.error(f"Failed to revoke preauth {preauth_id}: {e}")
-        return None
-
-
 async def create_request(
     to_user_id: int,
     amount: int,
@@ -193,20 +174,6 @@ async def deny_request(request_id: int) -> bool:
     except stackcoin.StackCoinError as e:
         logger.error(f"Failed to deny request {request_id}: {e}")
         return False
-
-
-async def get_request(request_id: int) -> dict | None:
-    """Get a request by ID."""
-    try:
-        req = await get_client().get_request(request_id=request_id)
-        return {
-            "id": req.id,
-            "amount": req.amount,
-            "status": req.status,
-        }
-    except stackcoin.StackCoinError as e:
-        logger.error(f"Failed to get request {request_id}: {e}")
-        return None
 
 
 async def get_guild_channel(guild_id: str) -> str | None:

--- a/luckypot/stk.py
+++ b/luckypot/stk.py
@@ -140,6 +140,15 @@ async def get_preauths(user_id: int | None = None) -> list[dict]:
         return []
 
 
+async def revoke_preauth(preauth_id: int) -> dict | None:
+    """Revoke a preauthorization."""
+    try:
+        return await get_client().revoke_preauth(preauth_id=preauth_id)
+    except stackcoin.StackCoinError as e:
+        logger.error(f"Failed to revoke preauth {preauth_id}: {e}")
+        return None
+
+
 async def create_request(
     to_user_id: int,
     amount: int,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "hikari-lightbulb>=3.1.1",
     "loguru>=0.7.3",
     "pydantic-settings>=2.0",
-    "stackcoin>=0.1.2",
+    "stackcoin>=0.1.4",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ requires-dist = [
     { name = "hikari-lightbulb", specifier = ">=3.1.1" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "pydantic-settings", specifier = ">=2.0" },
-    { name = "stackcoin", specifier = ">=0.1.2" },
+    { name = "stackcoin", specifier = ">=0.1.4" },
 ]
 
 [[package]]
@@ -605,16 +605,16 @@ wheels = [
 
 [[package]]
 name = "stackcoin"
-version = "0.1.2"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/cf/1a16f2a249c71d2c69079ca580bd677cf6a6f1e6d0f122466e07dfde475f/stackcoin-0.1.2.tar.gz", hash = "sha256:bc7de6d15a996e1e8b9a9fbf456f08168a64abec4d0e6e1b1b14f55f46d14570", size = 21699, upload-time = "2026-03-07T01:23:54.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/a8/cdea745b031351140c3895556cea99e1532675a9172068fda2d0c8f77a2e/stackcoin-0.1.4.tar.gz", hash = "sha256:55f1cb71e9f97766d0f12986f1ce4ae91e2c9205c398aa73d5ea49be135f3712", size = 22314, upload-time = "2026-05-05T15:20:32.659Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/fa/40c213ab43d993011e9e953263c5c8e6e1bf6eab05484f3d612f2e987503/stackcoin-0.1.2-py3-none-any.whl", hash = "sha256:91b612a449a1feb7923f6ee6c260c72c32e57809aea18bffa92157525566b5fa", size = 10399, upload-time = "2026-03-07T01:23:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c0/14b404cc94b519ca047143e3a666d5abe9e31290e8d32ec513c81bd84f4a/stackcoin-0.1.4-py3-none-any.whl", hash = "sha256:bc699fc173248cc8eeff9e98da0a31251f438cba081a2cec0f8beb969aaf4a0d", size = 10701, upload-time = "2026-05-05T15:20:31.57Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `enter_pot` always passes `use_preauth=True` — users with active preauths get instant entry confirmation, others fall back to the normal pending request flow
- Preauth budget exceeded or insufficient balance results in a silent skip (no ban), since the user didn't actively deny anything
- `/auto-enter` now automatically requests a preauth from StackCoin when the user opts in, showing appropriate UI states (active, pending, or newly requested)
- New `stk.py` wrappers: `create_preauth()`, `get_preauths()`, and `use_preauth` parameter on `create_request()`
- New UI builders for confirmed entries and preauth-enhanced auto-enter states

Depends on:
- StackCoin/stackcoin-python#4
- StackCoin/StackCoin (feat/preauthorization branch)